### PR TITLE
Change crossOrigin from this to self at initVideo

### DIFF
--- a/build/curtains.js
+++ b/build/curtains.js
@@ -1988,7 +1988,7 @@ Plane.prototype.loadVideos = function(videosArray) {
 
         video.sampler = videosArray[index].getAttribute("data-sampler") || null;
 
-        video.crossOrigin = this.crossOrigin;
+        video.crossOrigin = self.crossOrigin;
 
         // our video has not yet started for the first time
         video.firstStarted = false;


### PR DESCRIPTION
When using videos as a plane in React, it will give you an error because 'this' doesn't exist. Changed it to self.crossOrigin just like images already do.