### PR TITLE
Fix typos in getting started - post processing vertex shader

### DIFF
--- a/get-started.html
+++ b/get-started.html
@@ -1459,10 +1459,10 @@
                                         // use our aTextureCoord attributes as texture coords in our fragment shader
                                     </div>
                                     <div>
-                                        vvTextureCoord = aTextureCoord<span class="code-var">;</span>
+                                        vTextureCoord = aTextureCoord<span class="code-var">;</span>
                                     </div>
                                     <div>
-                                        vVertexPosition = vertexPosition<span class="code-var">;</span>
+                                        vVertexPosition = aVertexPosition<span class="code-var">;</span>
                                     </div>
                                 </div>
 


### PR DESCRIPTION
Fixes two small typos in the vertex shader provided in "Adding post-processing" in the Getting started guide.