### PR TITLE
requestVideoFrameCallback: wait for source

### DIFF
--- a/src/core/Texture.js
+++ b/src/core/Texture.js
@@ -887,7 +887,12 @@ export class Texture {
      ***/
     _videoFrameCallback() {
         this._willUpdate = true;
-        this.source.requestVideoFrameCallback(() => this._videoFrameCallback());
+        if(!this.source){
+          // wait for source to load
+          window.requestAnimationFrame(() => this._videoFrameCallback());
+        } else {
+          this.source.requestVideoFrameCallback(() => this._videoFrameCallback());
+        }
     }
 
 

--- a/src/core/Texture.js
+++ b/src/core/Texture.js
@@ -889,7 +889,7 @@ export class Texture {
         this._willUpdate = true;
         if(!this.source) {
             // wait for source to load
-            const waitForSource = this.renderer.nextRender(() => {
+            const waitForSource = this.renderer.nextRender.add(() => {
                 if(this.source) {
                     // source is ready, stop executing the callback
                     waitForSource.keep = false;

--- a/src/core/Texture.js
+++ b/src/core/Texture.js
@@ -887,9 +887,16 @@ export class Texture {
      ***/
     _videoFrameCallback() {
         this._willUpdate = true;
-        if(!this.source){
-          // wait for source to load
-          window.requestAnimationFrame(() => this._videoFrameCallback());
+        if(!this.source) {
+            // wait for source to load
+            const waitForSource = this.renderer.nextRender(() => {
+                if(this.source) {
+                    // source is ready, stop executing the callback
+                    waitForSource.keep = false;
+
+                    this.source.requestVideoFrameCallback(() => this._videoFrameCallback());
+                }
+            }, true);
         } else {
           this.source.requestVideoFrameCallback(() => this._videoFrameCallback());
         }


### PR DESCRIPTION
Thank you Martin for Open Sourcing this amazing library! I ran into the following error when working with videos and I want to share the fix that I applied to my local copy:
```
Texture.js:890 Uncaught TypeError: Cannot read properties of undefined (reading 'requestVideoFrameCallback')
    at Texture._videoFrameCallback
```