### PR TITLE
Add `"type": "module"` so tools know `.js` files are ESM format

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "curtainsjs",
   "version": "8.1.4",
   "description": "<h2>What is it ?</h2>\r <p>\r     Shaders are the next front-end web developpment big thing, with the ability to create very powerful 3D interactions and animations. A lot of very good javascript libraries already handle WebGL but with most of them it's kind of a headache to position your meshes relative to the DOM elements of your web page.\r </p>\r <p>\r     curtains.js was created with just that issue in mind. It is a small vanilla WebGL javascript library that converts HTML elements containing images and videos into 3D WebGL textured planes, allowing you to animate them via shaders.<br />\r     You can define each plane size and position via CSS, which makes it super easy to add WebGL responsive planes all over your pages.\r </p>\r <p>\r <a href=\"https://www.curtainsjs.com/\" title=\"Documentation\" target=\"_blank\">Documentation</a> - <a href=\"https://github.com/martinlaxenaire/curtainsjs\" title=\"GitHub\" target=\"_blank\">GitHub</a> </p>\r ",
+  "type": "module",
   "main": "src/index.mjs",
   "directories": {
     "example": "examples",


### PR DESCRIPTION
Packages use `"type": "module"` to indicate that `.js` files are ESM-format, which yours are. In some environments, like Node, `.js` files default to being interpreted as CJS when no `"type": "module"` is found in the ancestor package.json, and if the syntax in the `.js` file uses `import` or `export`, the runtime will crash immediately. So, as an example, if someone wanted to unit test a file that transitively pulls in any part of `curtainsjs` with `jest` or `mocha` (which run in Node), they would instantly see a crash.

I realize this package isn’t intended to be loaded in Node, but increasingly, bundlers are paying attention to package.json `"type"` too, and I wouldn’t be surprised if this is causing real problems for some bundler.

(I noticed this while reviewing community-contributed TypeScript types for this project at https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66027. The TypeScript types need to match in module format, and this invalid setup will confuse TypeScript itself.)

Info from publint: https://publint.dev/curtainsjs@8.1.4